### PR TITLE
Using a shorter Version of Swift's init syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ let container = TJSContainer(items: [.todo(todo1),
 do {
     let encoder = JSONEncoder()
     let data = try encoder.encode(container)
-    let json = String.init(data: data, encoding: .utf8)!
-    var components = URLComponents.init(string: "things:///add-json")!
-    let queryItem = URLQueryItem.init(name: "data", value: json)
+    let json = String(data: data, encoding: .utf8)!
+    var components = URLComponents(string: "things:///add-json")!
+    let queryItem = URLQueryItem(name: "data", value: json)
     components.queryItems = [queryItem]
     let url = components.url!
     UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/ThingsJSON.swift
+++ b/ThingsJSON.swift
@@ -103,8 +103,8 @@ class TJSModelItem {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let decodedType = try container.decode(String.self, forKey: .type)
         guard decodedType == self.type else {
-            let description = String.init(format: "Expected to decode a %@ but found a %@ instead.", self.type, decodedType)
-            let errorContext = DecodingError.Context.init(codingPath: [CodingKeys.type], debugDescription: description)
+            let description = String(format: "Expected to decode a %@ but found a %@ instead.", self.type, decodedType)
+            let errorContext = DecodingError.Context(codingPath: [CodingKeys.type], debugDescription: description)
             let expectedType = Swift.type(of: self)
             throw TJSError.invalidType(expectedType: expectedType, errorContext: errorContext)
         }


### PR DESCRIPTION
Throws away `.init(` when initializing objects/structures and uses the shorthand version which is more consistent with the rest of the code.

Thanks guys for this helpful helper structures 😀. 